### PR TITLE
Add a polling mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
 STOP: Instead you probably want to use something like this
 
-    easy_pwait() {
+    pwait_poll() {
         while ps -p $1 >/dev/null; do sleep 5; done
     }
 
-or a more portable version which can only check processes owned by the running user
+or a more portable version which can only check processes owned by the running
+user
 
-    easy_pwait() {
+    pwait_poll() {
         while kill -0 $1 2>/dev/null; do sleep 5; done
     }
 
 unless you need to get the process's exit code.
+
+For your convenience, pwait includes a shell script that provides this function.
+It's called `pwait_poll.sh`; just source it in your shell and then you can call
+`pwait_poll PID [DELAY]`.
 
 # What is pwait?
 
@@ -18,8 +23,8 @@ pwait is a small utility to wait for a process to finish. It works much like
 the `wait` command built in to bash and other shells, but it can wait for
 processes that aren't children of the terminal you run it in.
 
-One advantage of pwait over alternatives (like the shell function above) is
-that it can give you the exit code of the process you use it on, which is
+The advantage of pwait over the pwait_poll shell function above is that the
+full pwait can give you the exit code of the process you use it on, which is
 useful when you need to know whether a command in another terminal completed
 successfully.
 
@@ -41,7 +46,7 @@ caveats:
   OS's could be implemented, in principle.)
 - You have to have capability support enabled in the kernel and the capability
   manipulation shell utility `setcap` installed on the system (unless you run
-  pwait as root)
+  pwait as root or seteuid root)
 - It must be installed on a filesystem which supports extended attributes, so
   that you can add cap_sys_ptrace and/or cap_net_admin to the permitted
   capabilities list with setcap (again, unless you run it as root)
@@ -51,8 +56,9 @@ caveats:
   already being traced (such as one being run in a debugger). The netlink method
   doesn't suffer from these particular limitations, so it's the default.
 
-If this utility turns out to be useful, a future addition might be a
-polling mode which allows one to get around these difficulties.
+For completeness, pwait also implements a polling mode which does the same thing
+as the pwait_poll shell function. This mode cannot retrieve the exit code of the
+process, though, and it also won't catch the exact time at which the process ends.
 
 # Other pwaits
 

--- a/pwait_poll.sh
+++ b/pwait_poll.sh
@@ -1,0 +1,5 @@
+pwait_poll() {
+    while ps -p "$1" >/dev/null; do
+        sleep "${2:-5s}"
+    done
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,7 @@ include(CheckSymbolExists)
 check_symbol_exists(__GLIBC__ features.h _GNU_SOURCE)
 configure_file(config.h.in config.h)
 
-add_executable(pwait pwait.c ptrace.c netlink.c capabilities.c)
+add_executable(pwait pwait.c ptrace.c netlink.c poll.c capabilities.c)
 target_link_libraries(pwait cap)
 
 install(TARGETS pwait RUNTIME DESTINATION bin)

--- a/src/poll.c
+++ b/src/poll.c
@@ -1,0 +1,28 @@
+#include <syslog.h>
+#include <unistd.h>
+#include "pwait.h"
+
+
+static int process_exists(pid_t pid) {
+    // https://stackoverflow.com/a/31931126/56541
+    return getpgid(pid) >= 0;
+}
+
+
+static unsigned int poll_delay = 5;
+
+
+void set_delay(unsigned int delay) {
+    poll_delay = delay;
+}
+
+
+int wait_using_polling(pid_t pid) {
+    int return_code = -1;
+    while (process_exists(pid)) {
+        return_code = 0;
+        sleep(poll_delay);
+    }
+    syslog(LOG_INFO, "Process %d exited with unknown status", pid);
+    return return_code;
+}

--- a/src/pwait.h
+++ b/src/pwait.h
@@ -28,3 +28,5 @@ int acquire_capabilities(size_t n, const cap_value_t* capabilities_to_acquire);
 
 int wait_using_ptrace(pid_t pid);
 int wait_using_netlink(pid_t pid);
+int wait_using_polling(pid_t pid);
+void set_delay(unsigned int delay);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,3 +19,9 @@ add_test(
 )
 set_tests_properties(test-pwait-ptrace PROPERTIES ENVIRONMENT "PWAIT=$<TARGET_FILE:pwait>;PWAIT_METHOD=ptrace")
 set_tests_properties(test-pwait-ptrace PROPERTIES FIXTURES_REQUIRED pwait-setcap-fixture)
+
+add_test(
+    NAME test-pwait-poll
+    COMMAND "${CMAKE_CURRENT_LIST_DIR}/test_pwait.sh"
+)
+set_tests_properties(test-pwait-poll PROPERTIES ENVIRONMENT "PWAIT=$<TARGET_FILE:pwait>;PWAIT_METHOD=poll")

--- a/test/test_pwait.sh
+++ b/test/test_pwait.sh
@@ -138,8 +138,23 @@ run_all_tests() {
 }
 
 
+run_poll_tests() {
+    pwait_options=("--method=poll")
+    test_target_does_not_exist_after_pwait_exit
+    for delay in 1 2 5; do
+        pwait_options=("--method=poll" "--delay=$delay")
+        test_pwait_and_target_exit_times 10s "${delay}"
+    done
+}
+
+
 pwait_options=()
-if [[ -n "${PWAIT_METHOD:-}" ]]; then
-    pwait_options=("--method=${PWAIT_METHOD}")
-fi
-run_all_tests
+case "${PWAIT_METHOD:-}" in
+    poll)
+        run_poll_tests
+    ;;
+    *)
+        pwait_options=("--method=${PWAIT_METHOD}")
+        run_all_tests
+    ;;
+esac


### PR DESCRIPTION
This PR adds a third implementation of `pwait` which uses polling: it repeatedly checks whether a process with the given ID exists, with a configurable delay, and exits once it doesn't find such a process. Polling is less capable than the other two existing modes (netlink and ptrace) in that it can't capture the exact exit time or the exit code of the target process, but the benefit is that it doesn't need any special permissions.

Because polling doesn't capture the target's exit code, I had to use a different convention for the return code of this implementation. It will return 0 if a process is found on the first poll, otherwise it returns -1.

The PR also includes a shell function which does essentially the same thing (but is less careful about the return code). This basically gives people an easy way to use the function suggested in the README file.

I've also updated the test suite to exercise polling mode, to the extent possible.