### PR TITLE
Include unistd.h for geteuid()

### DIFF
--- a/src/ptrace.c
+++ b/src/ptrace.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <sysexits.h>
 #include <syslog.h>
+#include <unistd.h>
 #include "pwait.h"
 
 /* When the tracee is about to exit, waitpid returns a status


### PR DESCRIPTION
In `ptrace.c`, the code calls `geteuid()` which is declared in `unistd.h`, but it doesn't include `unistd.h`. It should, since I would like to follow the include-what-you-use approach. This commit fixes that.

I don't get have a good way to detect errors like this, but I hope to find one, either by adding [include-what-you-use](https://github.com/include-what-you-use/include-what-you-use) as a static check, or by finding a CI configuration in which compilation would fall.

Closes #12