### PR TITLE
Update branch name in GHA workflow file from master to main

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -3,10 +3,10 @@ name: Build and test with CMake
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
     branches:
-    - master
+    - main
 
 jobs:
   build:


### PR DESCRIPTION
This is necessary to have GitHub Actions workflows run after renaming the default branch from master to main.